### PR TITLE
resolving key error

### DIFF
--- a/Ang needs help.ipynb
+++ b/Ang needs help.ipynb
@@ -331,7 +331,7 @@
     }
    ],
    "source": [
-    "mesh.rename(columns={'Expr1000': 'initial_year', 'HSR_FINAL_YEAR': 'final_year'}).head()"
+    "mesh.rename(columns={'Expr1000': 'initial_year', 'HSR_FINAL_YEAR': 'final_year'},inplace=True).head()"
    ]
   },
   {


### PR DESCRIPTION
DataFrame.rename() by default does not set the changes made when renaming columns. Need to set inplace parameter to True

`df.rename({1: 2, 2: 4}, inplace=True)`

https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.rename.html
